### PR TITLE
Remove image fix

### DIFF
--- a/qrcode.js
+++ b/qrcode.js
@@ -441,6 +441,7 @@ var QRCode;
 		 */
 		Drawing.prototype.clear = function () {
 			this._oContext.clearRect(0, 0, this._elCanvas.width, this._elCanvas.height);
+			this._el.removeChild(this._elImage);
 			this._bIsPainted = false;
 		};
 		


### PR DESCRIPTION
When using a PNG QR code instead of a SVG QR code the images don't always get correctly deleted, this solutions removes the child image element from the element therefore removing the image