### PR TITLE
SVG should use crispEdges render specification to avoid occasional pixel border artifact

### DIFF
--- a/qrcode.js
+++ b/qrcode.js
@@ -195,7 +195,7 @@ var QRCode;
 				return el;
 			}
 
-			var svg = makeSVG("svg" , {'viewBox': '0 0 ' + String(nCount) + " " + String(nCount), 'width': '100%', 'height': '100%', 'fill': _htOption.colorLight});
+			var svg = makeSVG("svg" , {'viewBox': '0 0 ' + String(nCount) + " " + String(nCount), 'width': '100%', 'height': '100%', 'fill': _htOption.colorLight, 'shape-rendering': 'crispEdges'});
 			svg.setAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns:xlink", "http://www.w3.org/1999/xlink");
 			_el.appendChild(svg);
 


### PR DESCRIPTION
The upstream repository had filed issue [SVG subpixel blur problem #68](https://github.com/davidshimjs/qrcodejs/issues/68) which I also observed. Just adding a standard SVG attribute to the element creation, as suggested in the issue, eliminated the artifact in my testing.

Edit: looks like there was a PR upstream, but I missed it and it didn't reference the issue. It was https://github.com/davidshimjs/qrcodejs/pull/137